### PR TITLE
Fix AddAsync returning wrong entity

### DIFF
--- a/glassesRecommendation.Data/Repositories/GlassesRepository.cs
+++ b/glassesRecommendation.Data/Repositories/GlassesRepository.cs
@@ -21,8 +21,12 @@ namespace glassesRecommendation.Data.Repositories
             try
             {
                 _context.Glasses.Add(glasses);
-                long id = await _context.SaveChangesAsync(cancellationToken);
-                return await _context.Glasses.FirstOrDefaultAsync(g => g.Id == id, cancellationToken);
+                await _context.SaveChangesAsync(cancellationToken);
+
+                // the entity's Id will be set after SaveChangesAsync, so simply
+                // return the same instance instead of querying by the number of
+                // affected rows
+                return glasses;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- correct AddAsync to return the saved glasses entity instead of using SaveChanges result

## Testing
- `dotnet build glassesRecommendation.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_683f3e3fbab8832ea93c973078adbbbc