### PR TITLE
Add enum for FaceType to prevent invalid queries

### DIFF
--- a/glassesRecommendation.Core/DTOs/Requests/FaceTypeRequestDto.cs
+++ b/glassesRecommendation.Core/DTOs/Requests/FaceTypeRequestDto.cs
@@ -1,7 +1,9 @@
-﻿namespace glassesRecommendation.Core.DTOs.Requests
+using glassesRecommendation.Core.Enums;
+
+namespace glassesRecommendation.Core.DTOs.Requests
 {
-	public class FaceTypeRequestDto
-	{
-		public string FaceType { get; set; }
-	}
+    public class FaceTypeRequestDto
+    {
+        public FaceType FaceType { get; set; }
+    }
 }

--- a/glassesRecommendation.Core/Enums/FaceType.cs
+++ b/glassesRecommendation.Core/Enums/FaceType.cs
@@ -1,0 +1,11 @@
+namespace glassesRecommendation.Core.Enums
+{
+    public enum FaceType
+    {
+        Oval,
+        Oblong,
+        Heart,
+        Round,
+        Square
+    }
+}

--- a/glassesRecommendation.Core/Interfaces/IGlassesRepository.cs
+++ b/glassesRecommendation.Core/Interfaces/IGlassesRepository.cs
@@ -1,5 +1,6 @@
 ﻿using glassesRecommendation.Core.DTOs.Responses;
 using glassesRecommendation.Core.Models;
+using glassesRecommendation.Core.Enums;
 
 namespace glassesRecommendation.Core.Interfaces
 {
@@ -10,7 +11,7 @@ namespace glassesRecommendation.Core.Interfaces
         Task<GlassesResponseDto> UpdateAsync(Glasses glasses, CancellationToken cancellationToken);
         Task<PagedResult<Glasses>> FindAllAsync(int pageNumber, int pageSize, CancellationToken cancellationToken);
         Task<Glasses?> FindById(long id, CancellationToken cancellationToken);
-        Task<PagedResult<Glasses>> FindByFaceTypeAsync(string faceType, int pageNumber, int pageSize, CancellationToken cancellationToken);
+        Task<PagedResult<Glasses>> FindByFaceTypeAsync(FaceType faceType, int pageNumber, int pageSize, CancellationToken cancellationToken);
         Task<bool> FavouriteGlassesAsync(long id, CancellationToken cancellationToken);
         Task<bool> RemoveFavouriteGlassesAsync(long id, CancellationToken cancellationToken);
         Task<bool> IncreaseViewAsync(long id, CancellationToken cancellationToken);

--- a/glassesRecommendation.Core/Interfaces/IGlassesService.cs
+++ b/glassesRecommendation.Core/Interfaces/IGlassesService.cs
@@ -1,6 +1,7 @@
 ﻿using glassesRecommendation.Core.DTOs.Requests;
 using glassesRecommendation.Core.DTOs.Responses;
 using glassesRecommendation.Core.Models;
+using glassesRecommendation.Core.Enums;
 
 namespace glassesRecommendation.Core.Interfaces
 {
@@ -9,7 +10,7 @@ namespace glassesRecommendation.Core.Interfaces
         Task<GlassesResponseDto> SaveAsync(AddGlassesRequestDto addGlassesRequestDto, CancellationToken cancellationToken);
         Task<GlassesResponseDto> DeleteAsync(RemoveGlassesRequestDto removeGlassesRequestDto, CancellationToken cancellationToken);
         Task<PagedResult<Glasses>> GetAllGlassesAsync(int pageNumber, int pageSize, CancellationToken cancellationToken);
-        Task<PagedResult<Glasses>> GetGlassesSuitableFaceTypeAsync(string faceType, int pageNumber, int pageSize, CancellationToken cancellationToken);
+        Task<PagedResult<Glasses>> GetGlassesSuitableFaceTypeAsync(FaceType faceType, int pageNumber, int pageSize, CancellationToken cancellationToken);
         Task<bool> FavouriteGlassesAsync(long id, CancellationToken cancellationToken);
         Task<bool> RemoveFavouriteGlassesAsync(long id, CancellationToken cancellationToken);
         Task<bool> IncreaseViewAsync(long id, CancellationToken cancellationToken);

--- a/glassesRecommendation.Data/Repositories/GlassesRepository.cs
+++ b/glassesRecommendation.Data/Repositories/GlassesRepository.cs
@@ -1,6 +1,7 @@
 ﻿using glassesRecommendation.Core.DTOs.Responses;
 using glassesRecommendation.Core.Interfaces;
 using glassesRecommendation.Core.Models;
+using glassesRecommendation.Core.Enums;
 using glassesRecommendation.Data.Context;
 using Microsoft.EntityFrameworkCore;
 using System.Threading;
@@ -118,7 +119,7 @@ namespace glassesRecommendation.Data.Repositories
             }
         }
 
-        public async Task<PagedResult<Glasses>> FindByFaceTypeAsync(string faceType, int pageNumber, int pageSize, CancellationToken cancellationToken)
+        public async Task<PagedResult<Glasses>> FindByFaceTypeAsync(FaceType faceType, int pageNumber, int pageSize, CancellationToken cancellationToken)
         {
             IQueryable<Glasses> query = _context.Glasses.AsQueryable();
 
@@ -126,20 +127,20 @@ namespace glassesRecommendation.Data.Repositories
             {
                 switch (faceType)
                 {
-                    case "Oval":
-                        query = query.Where(g => g.Oval == true);
+                    case FaceType.Oval:
+                        query = query.Where(g => g.Oval);
                         break;
-                    case "Oblong":
-                        query = query.Where(g => g.Oblong == true);
+                    case FaceType.Oblong:
+                        query = query.Where(g => g.Oblong);
                         break;
-                    case "Heart":
-                        query = query.Where(g => g.Heart == true);
+                    case FaceType.Heart:
+                        query = query.Where(g => g.Heart);
                         break;
-                    case "Round":
-                        query = query.Where(g => g.Round == true);
+                    case FaceType.Round:
+                        query = query.Where(g => g.Round);
                         break;
-                    case "Square":
-                        query = query.Where(g => g.Square == true);
+                    case FaceType.Square:
+                        query = query.Where(g => g.Square);
                         break;
                     default:
                         query = query.Where(g => false);

--- a/glassesRecommendation.Service/Services/GlassesService.cs
+++ b/glassesRecommendation.Service/Services/GlassesService.cs
@@ -3,6 +3,7 @@ using glassesRecommendation.Core.DTOs.Requests;
 using glassesRecommendation.Core.DTOs.Responses;
 using glassesRecommendation.Core.Interfaces;
 using glassesRecommendation.Core.Models;
+using glassesRecommendation.Core.Enums;
 
 namespace glassesRecommendation.Service.Services
 {
@@ -77,7 +78,7 @@ namespace glassesRecommendation.Service.Services
             };
         }
 
-        public async Task<PagedResult<Glasses>> GetGlassesSuitableFaceTypeAsync(string faceType, int pageNumber, int pageSize, CancellationToken cancellationToken)
+        public async Task<PagedResult<Glasses>> GetGlassesSuitableFaceTypeAsync(FaceType faceType, int pageNumber, int pageSize, CancellationToken cancellationToken)
         {
             return await _glassesRepository.FindByFaceTypeAsync(faceType, pageNumber, pageSize, cancellationToken);
         }


### PR DESCRIPTION
## Summary
- add `FaceType` enum to restrict acceptable face type values
- use `FaceType` instead of plain string throughout the service and repository
- update DTO and interfaces accordingly

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet restore glassesRecommendation.sln`
- `dotnet build glassesRecommendation.sln --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_683f49a6a30c832ea9f20d23aa54dd04